### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "build_prod": "npm run build_dev && webpack --env.buildType prod --env.platform pdf && npm run dts_clean",
     "dts_clean": "node dts_cleaner.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/surveyjs/survey-pdf.git"
+  },
   "version": "1.8.60",
   "name": "survey-pdf",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* survey-pdf