### PR TITLE
Bug/89 acroforms not escaped symbols

### DIFF
--- a/src/jspdf_plugins/acroform.js
+++ b/src/jspdf_plugins/acroform.js
@@ -197,9 +197,13 @@ var jspdf = require('jspdf');
             : text;
         // split into array of words
         var textSplit = text.split(" ");
-        textSplit = textSplit.map(word => word.split("\n"));
+        textSplit = textSplit.map(function (word) {
+            return word.split("\n");
+        });
         if (!formObject.multiline) {
-            textSplit = textSplit.map(arr => [arr.join(" ")]);
+            textSplit = textSplit.map(function (arr) {
+                return [arr.join(" ")]
+            });
         }
 
         var fontSize = maxFontSize; // The Starting fontSize (The Maximum)
@@ -256,7 +260,7 @@ var jspdf = require('jspdf');
             var lineCount = 0;
             Line: for (var i = 0; i < textSplit.length; i++) {
             if (textSplit.hasOwnProperty(i)) {
-                let isWithNewLine = false;
+                var isWithNewLine = false;
                 if (textSplit[i].length !== 1 && currWord !== textSplit[i].length - 1) {
                 if (
                     (textHeight + lineSpacing) * (lineCount + 2) + lineSpacing >


### PR DESCRIPTION
Now in comment acroforms text `A\nB\nC`  looks like this:
![image](https://user-images.githubusercontent.com/15248977/138835819-e53bee12-4a1c-4433-b71b-ed286d1a5acb.png)
In text acroforms it looks like this:
![image](https://user-images.githubusercontent.com/15248977/138835894-ea7f0cb4-3e27-4224-9a8c-99fcba6063a7.png)
