### PR TITLE
Fix for https://github.com/surveyjs/service/issues/290: make onRenderHeader/Footer async

### DIFF
--- a/src/event_handler/event_handler.ts
+++ b/src/event_handler/event_handler.ts
@@ -21,8 +21,8 @@ export class EventAsync<T extends Function, Options> extends Event<T, Options> {
     }
 }
 export class EventHandler {
-    public static process_header_events(survey: SurveyPDF,
-        controller: DocController, packs: IPdfBrick[][]): void {
+    public static async process_header_events(survey: SurveyPDF,
+        controller: DocController, packs: IPdfBrick[][]): Promise<void> {
         if (!survey.haveCommercialLicense) {
             survey.onRenderHeader.add((_, canvas) => {
                 canvas.drawText({
@@ -32,9 +32,9 @@ export class EventHandler {
             });
         }
         for (let i: number = 0; i < packs.length; i++) {
-            survey.onRenderHeader.fire(survey, new DrawCanvas(packs[i], controller,
+            await survey.onRenderHeader.fire(survey, new DrawCanvas(packs[i], controller,
                 SurveyHelper.createHeaderRect(controller), packs.length, i + 1));
-            survey.onRenderFooter.fire(survey, new DrawCanvas(packs[i], controller,
+            await survey.onRenderFooter.fire(survey, new DrawCanvas(packs[i], controller,
                 SurveyHelper.createFooterRect(controller), packs.length, i + 1));
         }
     }

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -38,15 +38,15 @@ export class SurveyPDF extends SurveyModel {
      * @param survey SurveyPDF object that fires the event
      * @param canvas DrawCanvas object that you may use it to draw text and images in the page header
      */
-    public onRenderHeader: Event<(survey: SurveyPDF, canvas: DrawCanvas) => any, any> =
-        new Event<(survey: SurveyPDF, canvas: DrawCanvas) => any, any>();
+    public onRenderHeader: EventAsync<(survey: SurveyPDF, canvas: DrawCanvas) => any, any> =
+        new EventAsync<(survey: SurveyPDF, canvas: DrawCanvas) => any, any>();
     /**
      * The event in fired for every rendered page
      * @param survey SurveyPDF object that fires the event
      * @param canvas DrawCanvas object that you may use it to draw text and images in the page footer
      */
-    public onRenderFooter: Event<(survey: SurveyPDF, canvas: DrawCanvas) => any, any> =
-        new Event<(survey: SurveyPDF, canvas: DrawCanvas) => any, any>();
+    public onRenderFooter: EventAsync<(survey: SurveyPDF, canvas: DrawCanvas) => any, any> =
+        new EventAsync<(survey: SurveyPDF, canvas: DrawCanvas) => any, any>();
     /**
      * The event in fired for every rendered question
      * @param survey SurveyPDF object that fires the event
@@ -103,7 +103,7 @@ export class SurveyPDF extends SurveyModel {
         await this.waitForCoreIsReady();
         const flats: IPdfBrick[][] = await FlatSurvey.generateFlats(this, controller);
         const packs: IPdfBrick[][] = PagePacker.pack(flats, controller);
-        EventHandler.process_header_events(this, controller, packs);
+        await EventHandler.process_header_events(this, controller, packs);
         for (let i: number = 0; i < packs.length; i++) {
             for (let j: number = 0; j < packs[i].length; j++) {
                 if (controller.getNumberOfPages() === i) {

--- a/tests/event_header.test.ts
+++ b/tests/event_header.test.ts
@@ -30,7 +30,7 @@ test('Event render header simple text', async () => {
         canvas.drawText({
             text: 'SimpleHeaderText',
             rect: canvas.rect
-        })
+        });
     });
     let controller: DocController = new DocController(TestHelper.defaultOptions);
     let flats: IPdfBrick[][] = await FlatSurvey.generateFlats(survey, controller);
@@ -58,7 +58,7 @@ test('Event render header bold text', async () => {
             text: 'Doing sports',
             isBold: true,
             rect: canvas.rect
-        })
+        });
     });
     let controller: DocController = new DocController(TestHelper.defaultOptions);
     let flats: IPdfBrick[][] = await FlatSurvey.generateFlats(survey, controller);
@@ -88,7 +88,7 @@ test('Event render header left top text', async () => {
             text: text,
             horizontalAlign: HorizontalAlign.Left,
             verticalAlign: VerticalAlign.Top
-        })
+        });
     });
     let controller: DocController = new DocController(TestHelper.defaultOptions);
     let flats: IPdfBrick[][] = await FlatSurvey.generateFlats(survey, controller);
@@ -119,7 +119,7 @@ test('Event render header center middle text', async () => {
             text: text,
             horizontalAlign: HorizontalAlign.Center,
             verticalAlign: VerticalAlign.Middle
-        })
+        });
     });
     let controller: DocController = new DocController(TestHelper.defaultOptions);
     let flats: IPdfBrick[][] = await FlatSurvey.generateFlats(survey, controller);
@@ -136,7 +136,7 @@ test('Event render header center middle text', async () => {
         xRight: (headerRect.xRight - headerRect.xLeft + textSize.width) / 2.0,
         yTop: (headerRect.yBot - headerRect.yTop - textSize.height) / 2.0,
         yBot: (headerRect.yBot - headerRect.yTop + textSize.height) / 2.0
-    }
+    };
     TestHelper.equalRect(expect, packs[0][1], assumeText);
 });
 test('Event render footer center middle text', async () => {
@@ -156,14 +156,14 @@ test('Event render footer center middle text', async () => {
             text: text,
             horizontalAlign: HorizontalAlign.Center,
             verticalAlign: VerticalAlign.Middle
-        })
+        });
     });
     let controller: DocController = new DocController(TestHelper.defaultOptions);
     let flats: IPdfBrick[][] = await FlatSurvey.generateFlats(survey, controller);
     let packs: IPdfBrick[][] = PagePacker.pack(flats, controller);
     expect(packs.length).toBe(1);
     expect(packs[0].length).toBe(1);
-    EventHandler.process_header_events(survey, controller, packs);
+    await EventHandler.process_header_events(survey, controller, packs);
     expect(packs.length).toBe(1);
     expect(packs[0].length).toBe(2);
     let textSize: ISize = controller.measureText(text, 'normal', DocOptions.FONT_SIZE);
@@ -173,7 +173,7 @@ test('Event render footer center middle text', async () => {
         xRight: (footerRect.xLeft + footerRect.xRight + textSize.width) / 2.0,
         yTop: (footerRect.yTop + footerRect.yBot - textSize.height) / 2.0,
         yBot: (footerRect.yTop + footerRect.yBot + textSize.height) / 2.0
-    }
+    };
     TestHelper.equalRect(expect, packs[0][1], assumeText);
 });
 test('Have commercial license: true', async () => {


### PR DESCRIPTION
Earlier, drawImage function from canvas, which is mostly used in onRenderHeader event, was sync, but now it is async function, so we should make async all events that use canvas object